### PR TITLE
Fix: preserve previous milestone metrics on inso-metrics branch

### DIFF
--- a/dev-metrics.yml
+++ b/dev-metrics.yml
@@ -9,8 +9,8 @@ jobs:
   generate_and_commit_metrics:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # Give the default GITHUB_TOKEN write permission to commit and push the added or changed files to the repository.
-      pull-requests: write # Requires you go to Settings>Actions>Workflow Permissions>"Allow GitHub Actions to create and approve pull requests"
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout Local Repo
         uses: actions/checkout@v4
@@ -47,22 +47,28 @@ jobs:
         env:
           GITHUB_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
           ORGANIZATION: ${{ github.repository_owner }}
-      - name: Move Generated Metrics to Source Repo
+      - name: Move Generated Metrics to Temp Directory
         run: |
-          mkdir -p ./metrics
-          mv inso-gh-query-metrics/*${{ github.repository_owner }}.md metrics/
+          mkdir -p /tmp/new-metrics
+          mv inso-gh-query-metrics/*${{ github.repository_owner }}.md /tmp/new-metrics/
         shell: bash
-      - name: Auto Commit Results
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "[Automated] Milestone Metrics Update"
-          branch: inso-metrics
-          push_options: "--force"
-          create_branch: true
-          file_pattern: metrics/*.md
-          commit_user_name: GitHub Action
-          commit_user_email: action@github.com
-          commit_author: GitHub Action <action@github.com>
+      - name: Commit Metrics to inso-metrics branch
+        run: |
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+
+          git fetch origin inso-metrics 2>/dev/null || true
+
+          git checkout inso-metrics 2>/dev/null || git checkout -b inso-metrics
+
+          mkdir -p ./metrics
+          cp /tmp/new-metrics/*.md ./metrics/
+
+          git add metrics/*.md
+          git commit -m "[Automated] Milestone Metrics Update" || echo "No changes to commit"
+
+          git push origin inso-metrics
+        shell: bash
       - name: Create Pull Request
         run: |
           gh pr create --base ${{ github.ref }} --head "inso-metrics" --title "[Automated] Milestone Metrics Update" --body "This is an automated pull request to update the milestone metrics." --repo ${{ github.repository }} || echo "Command failed: Unable to create pull request. It might be due to the branch already existing or lack of permissions."


### PR DESCRIPTION
## Problem

When a new milestone starts, previous milestone Markdown reports are erased from the inso-metrics branch.

### Root Cause

The workflow used git-auto-commit-action@v4 with create_branch: true and push_options: "--force". Combined with actions/checkout@v4 defaulting to a shallow clone (fetch-depth: 1):

1. Checkout only fetches main — remote branches like inso-metrics aren't available
2. git-auto-commit-action can't find inso-metrics, so it creates a **fresh branch from main** every run
3. The script defaults to optimize_milestone_fetch=True (only processes the **current** milestone)
4. Force-push overwrites the entire branch → previous milestone files are gone

## Fix

Replaces git-auto-commit-action with manual git steps that:
- Move generated files to /tmp/new-metrics/ before checkout (avoids conflicts)
- Fetch the existing inso-metrics branch (if it exists)
- Checkout existing branch or create new one from main
- Copy new metrics alongside existing files
- Push without --force to preserve history and old milestone files

## Changes

| Step | Before | After |
| --- | --- | --- |
| Move metrics | mv directly into ./metrics/ | Move to /tmp/new-metrics/ first to avoid checkout conflicts |
| Commit | git-auto-commit-action@v4 action | Manual git: fetch → checkout → copy → commit → push |
| Push | Force-push overwrites branch | Normal push preserves history and old milestone files |