### PR TITLE
Metrics graphs to GitHub pages

### DIFF
--- a/dev-metrics.yml
+++ b/dev-metrics.yml
@@ -47,11 +47,13 @@ jobs:
         env:
           GITHUB_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
           ORGANIZATION: ${{ github.repository_owner }}
+          PAGES_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
       - name: Move Generated Metrics to Temp Directory
         run: |
           mkdir -p /tmp/new-metrics
           mv inso-gh-query-metrics/*${{ github.repository_owner }}.md /tmp/new-metrics/
           mv inso-gh-query-metrics/*${{ github.repository_owner }}.html /tmp/new-metrics/ 2>/dev/null || true
+          mv inso-gh-query-metrics/index.html /tmp/new-metrics/ 2>/dev/null || true
         shell: bash
       - name: Commit Metrics to inso-metrics branch
         run: |
@@ -70,6 +72,22 @@ jobs:
           git commit -m "[Automated] Milestone Metrics Update" || echo "No changes to commit"
 
           git push origin inso-metrics
+        shell: bash
+      - name: Deploy Interactive Charts to GitHub Pages
+        run: |
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+
+          git fetch origin gh-pages 2>/dev/null || true
+          git checkout gh-pages 2>/dev/null || git checkout -b gh-pages
+
+          mkdir -p ./metrics
+          cp /tmp/new-metrics/*.html ./metrics/
+          cp /tmp/new-metrics/index.html ./index.html 2>/dev/null || true
+
+          git add metrics/*.html index.html
+          git commit -m "[Automated] Deploy Interactive Charts" || echo "No changes to commit"
+          git push origin gh-pages
         shell: bash
       - name: Create Pull Request
         run: |

--- a/dev-metrics.yml
+++ b/dev-metrics.yml
@@ -64,6 +64,7 @@ jobs:
 
           mkdir -p ./metrics
           cp /tmp/new-metrics/*.md ./metrics/
+          cp /tmp/new-metrics/*.html ./metrics/ 2>/dev/null || true
 
           git add metrics/*.md metrics/*.html
           git commit -m "[Automated] Milestone Metrics Update" || echo "No changes to commit"

--- a/src/generateMilestoneMetricsForActions.py
+++ b/src/generateMilestoneMetricsForActions.py
@@ -13,7 +13,7 @@ from src.io.markdown import (
     writeSprintTaskCompletionToMarkdown,
     writeWeeklyDiscussionParticipationToMarkdown,
 )
-from src.io.charts import writeCycleLeadTimeChart
+from src.io.charts import writeCycleLeadTimeChart, writeIndexPage, getChartUrl
 from src.legacy.generateMilestoneMetricsForActions import generateMetricsFromV1Config
 from src.utils.constants import pr_tz
 from src.getTeamMembers import getTeamMembers
@@ -70,6 +70,7 @@ def generateMetricsFromV2Config(
             milestones = {milestone: milestones[milestone]}
 
     print("Milestones: ", ", ".join(milestones.keys()))
+    chart_files: list[tuple[str, str]] = []
     for milestone, mData in milestones.items():
         logger = logging.getLogger(milestone)
         logger.setLevel(verbosity)
@@ -150,6 +151,23 @@ def generateMetricsFromV2Config(
             milestone_data=team_metrics,
             html_file_path=output_chart_path,
             logger=logger,
+        )
+        # Add link to interactive chart in Markdown report
+        pages_base_url = os.environ.get("PAGES_BASE_URL", "")
+        if pages_base_url:
+            chart_url = getChartUrl(pages_base_url, output_chart_path)
+            with open(output_markdown_path, mode="a") as md_file:
+                md_file.write(f"\n## 📊 Interactive Charts\n\n")
+                md_file.write(f"[View Cycle Time & Lead Time Charts]({chart_url})\n")
+            logger.info(f"Chart link added to Markdown report: {chart_url}")
+        chart_files.append((milestone, output_chart_path))
+
+    # Generate index page listing all chart files
+    if chart_files:
+        writeIndexPage(
+            chart_files=chart_files,
+            index_file_path="index.html",
+            logger=logging.getLogger(__name__),
         )
 
 

--- a/src/io/charts.py
+++ b/src/io/charts.py
@@ -1,6 +1,72 @@
 import json
 import logging
+import os
 from src.utils.models import MilestoneData
+
+
+def getChartUrl(pages_base_url: str, html_filename: str) -> str:
+    """Build the full GitHub Pages URL for a chart file."""
+    base = pages_base_url.rstrip("/")
+    return f"{base}/metrics/{html_filename}"
+
+
+def writeIndexPage(
+    chart_files: list[tuple[str, str]],
+    index_file_path: str,
+    logger: logging.Logger | None = None,
+):
+    """
+    Generates an index.html landing page listing all available chart files.
+
+    Args:
+        chart_files: List of (display_name, html_filename) tuples
+        index_file_path: Path to write the index.html file
+    """
+    if logger is None:
+        logger = logging.getLogger(__name__)
+
+    items_html = "\n".join(
+        f'        <li><a href="metrics/{fname}">{name}</a></li>'
+        for name, fname in chart_files
+    )
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Interactive Metrics Charts</title>
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 40px;
+            background: #f6f8fa;
+            color: #1f2328;
+        }}
+        h1 {{ font-size: 1.5rem; }}
+        ul {{ list-style: none; padding: 0; }}
+        li {{
+            margin: 0.5rem 0;
+            padding: 0.75rem 1rem;
+            background: #fff;
+            border: 1px solid #d0d7de;
+            border-radius: 6px;
+        }}
+        a {{ color: #0969da; text-decoration: none; font-weight: 500; }}
+        a:hover {{ text-decoration: underline; }}
+    </style>
+</head>
+<body>
+    <h1>📊 Interactive Metrics Charts</h1>
+    <ul>
+{items_html}
+    </ul>
+</body>
+</html>"""
+
+    with open(index_file_path, mode="w") as f:
+        f.write(html)
+    logger.info(f"Index page written to {index_file_path}")
 
 
 def writeCycleLeadTimeChart(


### PR DESCRIPTION
The new metrics graphs live in HTML pages. These are not rendered by GitHub when just visiting the files. To have them rendered, move them to their own GitHub pages sub-directory.